### PR TITLE
Fixed link to user profile does not use the configured user profile path

### DIFF
--- a/core-standards.php
+++ b/core-standards.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Core Standards
-  Version: 1.13.0
+  Version: 1.13.1
   Text Domain: core-standards
   Description: Standard refinements.
   Author: netzstrategen

--- a/src/UserLoginForm.php
+++ b/src/UserLoginForm.php
@@ -31,7 +31,7 @@ class UserLoginForm {
     if (!empty($args['show_reset_link']) && $link = static::getResetPasswordLink()) {
       $links .= '<div class="user-login-form-reset-password-link-wrapper">' . $link . '</div>';
     }
-    if (!empty($args['show_profile_link']) && $link = static::getProfileLink($redirect)) {
+    if (!empty($args['show_profile_link']) && $link = static::getProfileLink(!empty($args['profile_path']) ? $args['profile_path'] : '')) {
       $links .= '<div class="user-login-form-account-link-wrapper">' . $link . '</div>';
     }
     if (!empty($args['show_logout_link']) && $link = static::getLogoutLink($redirect)) {


### PR DESCRIPTION
The redirect path is supposed to be used for the initial redirect after logging in only.