### PR TITLE
Disabled remember_me checkbox by default.

### DIFF
--- a/src/UserFrontend.php
+++ b/src/UserFrontend.php
@@ -61,6 +61,7 @@ class UserFrontend {
    */
   public static function login_form_defaults(array $args) {
     $args['value_remember'] = TRUE;
+    $args['remember'] = FALSE;
     return $args;
   }
 
@@ -87,6 +88,9 @@ body, html {
   background-size: auto;
   width: auto;
   height: 50px;
+}
+#loginform .forgetmenot {
+  display: none;
 }
 </style>
 


### PR DESCRIPTION
On the Asana ticket @sun mentioned that the plugin should already hide Remember Me checkbox as default behaviour:

> […] but shouldn't have been, because core-standards hides it by default – or should hide it by default.

Instead, checking the code, I found a comment that said just the opposite [`// Enable Remember Me by default.`]. In addition, this code seems not working since also if values are changed (from 1 to 0 and from TRUE to FALSE) the checkbox is still displayed.

I research a little bit and I found that we should:

1. manipulate the `remember` values of the `$args` array using the `login_form_defaults` hook for the login form displayed in the frontend;
2. use a PHP `preg_replace` (better than an inline CSS solution IMO) to clean the backend form in the `wp-login.php`. 

In this PR I tried to follow this two steps but since I'm not sure what the previous code did and why it was implemented (Different intended behaviour? Outdated code?) I don't change it yet, waiting a feedback first.
