### PR TITLE
Fixed Facebook embeds keep within wrapper borders.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -65,6 +65,9 @@ class Plugin {
     // Add teaser image to RSS feeds.
     add_action('rss2_item', __NAMESPACE__ . '\Feed::rss2_item');
 
+    // Fix Facebook embeds to keep within wrapper borders.
+    add_filter('oembed_fetch_url', __CLASS__ . '::oembed_fetch_url', 10, 3);
+
     UserFrontend::init();
   }
 
@@ -151,6 +154,18 @@ class Plugin {
    */
   public static function getBasePath() {
     return dirname(__DIR__);
+  }
+
+  /**
+   * Fix Facebook embeds to keep within wrapper borders.
+   *
+   * @implements oembed_fetch_url
+   */
+  public static function oembed_fetch_url($provider, $url, $args) {
+    if (strpos($url, 'facebook.com')) {
+      $provider = add_query_arg( 'maxwidth', '100%', $provider );
+    }
+    return $provider;
   }
 
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -65,7 +65,7 @@ class Plugin {
     // Add teaser image to RSS feeds.
     add_action('rss2_item', __NAMESPACE__ . '\Feed::rss2_item');
 
-    // Fix Facebook embeds to keep within wrapper borders.
+    // Ensure that Facebook embeds do not exceed available content width.
     add_filter('oembed_fetch_url', __CLASS__ . '::oembed_fetch_url', 10, 3);
 
     UserFrontend::init();
@@ -163,7 +163,7 @@ class Plugin {
    */
   public static function oembed_fetch_url($provider, $url, $args) {
     if (strpos($url, 'facebook.com')) {
-      $provider = add_query_arg( 'maxwidth', '100%', $provider );
+      $provider = add_query_arg('maxwidth', '100%', $provider);
     }
     return $provider;
   }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -40,11 +40,11 @@ class Plugin {
     // @see https://developer.mozilla.org/en-US/Firefox/Privacy/Tracking_Protection
     add_filter('oembed_providers', __CLASS__ . '::oembed_providers');
 
-    // Add wrapper to oEmbed elements.
-    add_filter('embed_oembed_html', __CLASS__ . '::embed_oembed_html', 10, 4);
-
     // Ensure that Facebook embeds do not exceed available content width.
     add_filter('oembed_fetch_url', __CLASS__ . '::oembed_fetch_url', 10, 3);
+
+    // Add wrapper to oEmbed elements.
+    add_filter('embed_oembed_html', __CLASS__ . '::embed_oembed_html', 10, 4);
 
     // Allow SVG files in media library.
     add_filter('upload_mimes', __CLASS__ . '::upload_mime_types');

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -43,6 +43,9 @@ class Plugin {
     // Add wrapper to oEmbed elements.
     add_filter('embed_oembed_html', __CLASS__ . '::embed_oembed_html', 10, 4);
 
+    // Ensure that Facebook embeds do not exceed available content width.
+    add_filter('oembed_fetch_url', __CLASS__ . '::oembed_fetch_url', 10, 3);
+
     // Allow SVG files in media library.
     add_filter('upload_mimes', __CLASS__ . '::upload_mime_types');
 
@@ -64,9 +67,6 @@ class Plugin {
     }
     // Add teaser image to RSS feeds.
     add_action('rss2_item', __NAMESPACE__ . '\Feed::rss2_item');
-
-    // Ensure that Facebook embeds do not exceed available content width.
-    add_filter('oembed_fetch_url', __CLASS__ . '::oembed_fetch_url', 10, 3);
 
     UserFrontend::init();
   }


### PR DESCRIPTION
Problem
* After updating WordPress Core recently, Facebook content embedded through a oEmbed URL exceeds the available space (width) of the layout / main content area on one of our websites.

Details
* The embed code of `wp-includes/class-oembed.php` forces the the `maxwidth` parameter as integer for the oembed endpoint.
* This works with all platforms as CSS `max-width` with an CSS line setting `width: 100%`.
* But for Facebook the output is `width: 750px`, which is forced via JavaScript.

Proposed solution
1. Use `oembed_fetch_url` filter to modify the query params overriding `max-width` with a '100%' string in case the content is from facebook.

Notes
* The oEmbed cache is stored in `wp_postmeta` with keys `_oembed_RANDOMHASH`.
