### PR TITLE
Full-width images on an own line in post content are wrapped into paragraphs

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -62,6 +62,9 @@ class Plugin {
 
     add_shortcode('user-login-form', __NAMESPACE__ . '\UserLoginForm::getOutput');
 
+    // Prevent full-width images from getting wrapped into paragraphs.
+    add_filter('the_content', __CLASS__ . '::the_content', 9);
+
     if (is_admin()) {
       return;
     }
@@ -69,6 +72,14 @@ class Plugin {
     add_action('rss2_item', __NAMESPACE__ . '\Feed::rss2_item');
 
     UserFrontend::init();
+  }
+
+  /**
+   * @implements the_content
+   */
+  public static function the_content($html) {
+    $html = preg_replace('@^(?:<a [^>]+>)?<img [^>]+>(?:</a>)?\s*$@m', '<figure>$0</figure>', $html);
+    return $html;
   }
 
   /**


### PR DESCRIPTION
This causes problems to apply a consistent styling for paragraphs and images in CSS, especially concerning the spacing between subsequently following paragraphs with an image in between.

The code unconditionally outputs a figure HTML5 element without checking whether the theme supports HTML5, because that is the assumed default for all themes in 2017.