### PR TITLE
Changed wp_mail sender domain to be generated from wordpress internal function.

### DIFF
--- a/core-standards.php
+++ b/core-standards.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Core Standards
-  Version: 1.15.0
+  Version: 1.16.0
   Text Domain: core-standards
   Description: Standard refinements.
   Author: netzstrategen

--- a/src/Mail.php
+++ b/src/Mail.php
@@ -19,9 +19,7 @@ class Mail {
     $from_name = get_bloginfo('name');
     $from_email = get_option('admin_email');
     // Ensure that emails from staging site instances can still be identified.
-    if (isset($_SERVER['SERVER_NAME'])) {
-      $from_email = strtok($from_email, '@') . '@' . str_replace('www.', '', $_SERVER['SERVER_NAME']);
-    }
+    $from_email = strtok($from_email, '@') . '@' . str_replace('www.', '', parse_url(network_home_url(), PHP_URL_HOST));
     $from_header = "From: $from_name <$from_email>";
     if (empty($message['headers'])) {
       $message['headers'] = [$from_header];


### PR DESCRIPTION
Due to a security vulnerability the email sender domain should not be generated from `$_SERVER['SERVER_NAME']` but use an internal WP function instead.

- https://exploitbox.io/vuln/WordPress-Exploit-4-7-Unauth-Password-Reset-0day-CVE-2017-8295.html
- https://core.trac.wordpress.org/ticket/25239#comment:91