### PR TITLE
Fixed user logged out when closing the web browser.

### DIFF
--- a/assets/user-login-form.css
+++ b/assets/user-login-form.css
@@ -1,0 +1,3 @@
+#loginform .login-remember {
+  display: none;
+}

--- a/src/UserFrontend.php
+++ b/src/UserFrontend.php
@@ -60,8 +60,20 @@ class UserFrontend {
    * @implements login_form_defaults
    */
   public static function login_form_defaults(array $args) {
+    if (file_exists(get_stylesheet_directory() . '/dist/styles/login.css')) {
+      wp_enqueue_style('theme/login', get_stylesheet_directory_uri() . '/dist/styles/login.css');
+    }
+    else {
+      echo <<<EOD
+<style>
+#loginform .login-remember {
+  display: none;
+}
+</style
+
+EOD;
+    }
     $args['value_remember'] = TRUE;
-    $args['remember'] = FALSE;
     return $args;
   }
 

--- a/src/UserFrontend.php
+++ b/src/UserFrontend.php
@@ -60,19 +60,7 @@ class UserFrontend {
    * @implements login_form_defaults
    */
   public static function login_form_defaults(array $args) {
-    if (file_exists(get_stylesheet_directory() . '/dist/styles/login.css')) {
-      wp_enqueue_style('theme/login', get_stylesheet_directory_uri() . '/dist/styles/login.css');
-    }
-    else {
-      echo <<<EOD
-<style>
-#loginform .login-remember {
-  display: none;
-}
-</style
-
-EOD;
-    }
+    wp_enqueue_style('core-standards/login', Plugin::getBaseUrl() . '/assets/user-login-form.css');
     $args['value_remember'] = TRUE;
     return $args;
   }


### PR DESCRIPTION
Problem:
- The users are logged out when closed the web browser

Details:
- On this commit, the checkbox was removed to activate the feature by default: https://github.com/netzstrategen/wordpress-core-standards/pull/2/files
- But as we can see there this is removing all the HTML element: https://core.trac.wordpress.org/browser/tags/4.8/src/wp-includes/general-template.php#L482
- When the login form is processed if the form element doesn't exist no value is taken: https://core.trac.wordpress.org/browser/tags/4.8/src/wp-login.php#L891

Proposed solution:
- Set back the form element and hide it via CSS