### PR TITLE
Fixed PHP notice when user is not logged in.

### DIFF
--- a/src/UserLoginForm.php
+++ b/src/UserLoginForm.php
@@ -71,7 +71,7 @@ class UserLoginForm {
     if (static::isLoggedIn()) {
       return static::getProfileLink($redirect);
     }
-    $redirect = $redirect ?: home_url(add_query_arg());
+    $redirect = $redirect ?: home_url(add_query_arg(NULL, NULL));
     $link_text = apply_filters('core_standards/user_login_form/link_text_login', __('Log in'));
     return '<a href="' . wp_login_url($redirect) . '" class="user-login-form-login-link">' . $link_text . '</a>';
   }


### PR DESCRIPTION
A PHP notice is shown when user is not logged in. The reason seems to be the lack of a needed parameter in the call to `add_query_arg()` in method `UserLoginForm::getLoginLink()` that returns the login link to insert in the secondary menu.

`add_query_arg()` is correctly used in method `UserLoginForm::getLogoutLink()`.

https://developer.wordpress.org/reference/functions/add_query_arg/