### PR TITLE
Added cleanup of old post revisions.

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -325,14 +325,16 @@ EOD;
   public static function cron_revision_cleanup($limit = 100) {
     global $wpdb;
 
+    $post_types = 'post, product, product_variation';
+
     // Revisions of posts that were last modified a long time ago (3 months) are
     // no longer necessary and can be cleaned up.
     $revision_ids = $wpdb->get_col($wpdb->prepare("SELECT revision.ID
 FROM $wpdb->posts revision
-INNER JOIN $wpdb->posts parent ON parent.ID = revision.post_parent AND parent.post_type = %s
+INNER JOIN $wpdb->posts parent ON parent.ID = revision.post_parent AND parent.post_type IN ($post_types)
 WHERE revision.post_type = 'revision' AND revision.post_modified_gmt < %s AND revision.post_name NOT LIKE '%autosave%'
 LIMIT 0,%d
-", 'post', date('Y-m-d', strtotime('today - ' . static::CRON_EVENT_REVISION_CLEANUP_RETAIN_DAYS . ' days')), $limit));
+", date('Y-m-d', strtotime('today - ' . static::CRON_EVENT_REVISION_CLEANUP_RETAIN_DAYS . ' days')), $limit));
     foreach ($revision_ids as $revision_id) {
       wp_delete_post_revision($revision_id);
     }

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -27,6 +27,8 @@ class Schema {
    * register_deactivation_hook() callback.
    */
   public static function deactivate() {
+    // Remove scheduled revision cleanup cron event.
+    wp_clear_scheduled_hook(Admin::CRON_EVENT_REVISION_CLEANUP);
   }
 
   /**


### PR DESCRIPTION
Problem
* Very big database due to too many revisions.

Goal
* Retain clean database.

Proposed solution
* For static content (post type "page"), store all / infinite amount of revisions. (-1)
* For dynamic content (post type "post"), store only revisions within 6 months after article publishing date. (0)
* For any other content types, do not modify the revision saving.
* Implement cron job to periodically clean up existing revisions matching this logic.

Notes
* This also affects edits of evergreen articles — editors need to make sure to update the publishing date in such cases.

Ticket: https://app.asana.com/0/74314752394866/887937202215136