### PR TITLE
Added missing indexes for posts, postmeta, and usermeta tables.

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -108,9 +108,9 @@ class Schema {
     self::ensureIndex('options', 'autoload', 'autoload');
     self::ensureIndex('posts', 'type_status_date_gmt', 'post_type, post_status, post_date_gmt');
     self::ensureIndex('posts', 'type_status_comment_count', 'post_type, post_status, comment_count');
-    self::ensureIndex('usermeta', 'user_id_meta_key', 'user_id, meta_key');
     self::ensureIndex('posts', 'guid', 'guid');
     self::ensureIndex('postmeta', 'meta_value', 'meta_value(60)');
+    self::ensureIndex('usermeta', 'user_id_meta_key', 'user_id, meta_key');
   }
 
   /**

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -106,6 +106,10 @@ class Schema {
    */
   public static function cron_ensure_indexes() {
     self::ensureIndex('options', 'autoload', 'autoload');
+    self::ensureIndex('posts', 'type_status_date_gmt', 'post_type, post_status, post_date_gmt');
+    self::ensureIndex('posts', 'type_status_comment_count', 'post_type, post_status, comment_count');
+    self::ensureIndex('wp_usermeta', 'user_id_meta_key', 'user_id, meta_key');
+    self::ensureIndex('posts', 'guid', 'guid');
   }
 
   /**

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -105,11 +105,31 @@ class Schema {
    * Cron event callback to ensure proper database indexes.
    */
   public static function cron_ensure_indexes() {
+    // Core queries all options with autoload=yes on every request, which becomes
+    // slower when there are plenty of rows (e.g., due to options that ought to
+    // be transients but are not).
     self::ensureIndex('options', 'autoload', 'autoload');
-    self::ensureIndex('posts', 'type_status_date_gmt', 'post_type, post_status, post_date_gmt');
-    self::ensureIndex('posts', 'type_status_comment_count', 'post_type, post_status, comment_count');
-    self::ensureIndex('posts', 'guid', 'guid');
+
+    // Core as well as various plugins attempt to find posts having certain meta
+    // values, but there is no index on the values by default as it is a longtext
+    // column.
     self::ensureIndex('postmeta', 'meta_value', 'meta_value(60)');
+
+    // Data migration and import scripts and plugins are trying to locate
+    // previously migrated content by its UUID, but the GUID column does not have
+    // an index.
+    self::ensureIndex('posts', 'guid', 'guid');
+
+    // Some code (probably the Dashboard) attempts to retrieve the most commented
+    // posts on the site for statistics, but there is no index for this query.
+    self::ensureIndex('posts', 'type_status_comment_count', 'post_type, post_status, comment_count');
+
+    // Some code (probably the Dashboard) retrieves the GMT date (only the
+    // timestamp without post ID) of the most recent published post of all posts,
+    // which takes long with a lot of rows.
+    self::ensureIndex('posts', 'type_status_date_gmt', 'post_type, post_status, post_date_gmt');
+
+    // Administrative user listing attempts to filter users by meta fields.
     self::ensureIndex('usermeta', 'user_id_meta_key', 'user_id, meta_key');
   }
 

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -108,7 +108,7 @@ class Schema {
     self::ensureIndex('options', 'autoload', 'autoload');
     self::ensureIndex('posts', 'type_status_date_gmt', 'post_type, post_status, post_date_gmt');
     self::ensureIndex('posts', 'type_status_comment_count', 'post_type, post_status, comment_count');
-    self::ensureIndex('wp_usermeta', 'user_id_meta_key', 'user_id, meta_key');
+    self::ensureIndex('usermeta', 'user_id_meta_key', 'user_id, meta_key');
     self::ensureIndex('posts', 'guid', 'guid');
   }
 

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -110,6 +110,7 @@ class Schema {
     self::ensureIndex('posts', 'type_status_comment_count', 'post_type, post_status, comment_count');
     self::ensureIndex('usermeta', 'user_id_meta_key', 'user_id, meta_key');
     self::ensureIndex('posts', 'guid', 'guid');
+    self::ensureIndex('postmeta', 'meta_value', 'meta_value(60)');
   }
 
   /**


### PR DESCRIPTION
### Ticket
https://app.asana.com/0/74314752394866/113067189988275/f
https://app.asana.com/0/74314752394866/113067189988278/f
https://app.asana.com/0/74314752394866/222511037896575/f
https://app.asana.com/0/74314752394866/110162484698981/f

### Description
Adding indices to posts and user_meta tables to reduce execution time.

———— Background information added by @sun 
#### Fix slow query in wp_posts.guid (migration/import)
```sql
# User@Host: netzstrategen[netzstrategen] @  [10.0.81.52]
# Query_time: 0.285832  Lock_time: 0.000035 Rows_sent: 1  Rows_examined: 291967
SET timestamp=1460112225;
SELECT ID FROM wp_posts WHERE guid = 'http://customer/supplier/5cd05627-0754-4347-aee8-a5e5f6a7f70b' LIMIT 0,1;

ALTER TABLE wp_posts ADD INDEX guid (guid);
```

#### Fix slow query for wp_posts.comment_count
Origin:  Dashboard?

```sql
# Time: 160415 13:37:52
# User@Host: netzstrategen[netzstrategen] @  [10.0.81.52]
# Query_time: 2.544098  Lock_time: 0.000048 Rows_sent: 5  Rows_examined: 810035
SET timestamp=1460720272;
SELECT   wp_posts.ID FROM wp_posts  WHERE 1=1  AND wp_posts.post_type = 'post' AND ((wp_posts.post_status = 'publish'))  ORDER BY wp_posts.comment_count DESC LIMIT 0, 5;


mysql> EXPLAIN SELECT   wp_posts.ID FROM wp_posts  WHERE 1=1  AND wp_posts.post_type = 'post' AND ((wp_posts.post_status = 'publish'))  ORDER BY wp_posts.comment_count DESC LIMIT 0, 5\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: wp_posts
         type: ref
possible_keys: type_status_date,type_status_mime_type
          key: type_status_date
      key_len: 164
          ref: const,const
         rows: 679816
        Extra: Using where; Using filesort
1 row in set (0.01 sec)

mysql> ALTER TABLE wp_posts ADD INDEX type_status_comment_count (post_type, post_status, comment_count);
Query OK, 0 rows affected (16.16 sec)
Records: 0  Duplicates: 0  Warnings: 0

mysql> EXPLAIN SELECT   wp_posts.ID FROM wp_posts  WHERE 1=1  AND wp_posts.post_type = 'post' AND ((wp_posts.post_status = 'publish'))  ORDER BY wp_posts.comment_count DESC LIMIT 0, 5\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: wp_posts
         type: ref
possible_keys: type_status_date,type_status_mime_type,type_status_comment_count
          key: type_status_comment_count
      key_len: 164
          ref: const,const
         rows: 679857
        Extra: Using where; Using index
1 row in set (0.00 sec)


mysql> SELECT   wp_posts.ID FROM wp_posts  WHERE 1=1  AND wp_posts.post_type = 'post' AND ((wp_posts.post_status = 'publish'))  ORDER BY wp_posts.comment_count DESC LIMIT 0, 5\G
*************************** 1. row ***************************
ID: 1363026
*************************** 2. row ***************************
ID: 1364201
*************************** 3. row ***************************
ID: 1362497
*************************** 4. row ***************************
ID: 1365553
*************************** 5. row ***************************
ID: 1365486
5 rows in set (0.00 sec)
```

#### Fix slow query for wp_posts.post_date_gmt
Origin:  Dashboard?

```sql
# Time: 160415 15:47:39
# User@Host: netzstrategen[netzstrategen] @  [10.0.81.52]
# Query_time: 2.493347  Lock_time: 0.000207 Rows_sent: 1  Rows_examined: 817175
SET timestamp=1460728059;
SELECT post_date_gmt FROM wp_posts WHERE post_status = 'publish' AND post_type IN ('post', 'page', 'attachment', 'pronamic_pay_form', 'tribe_events', 'tribe_venue', 'tribe_organizer', 'gallery', 'sports', 'epaper') ORDER BY post_date_gmt DESC LIMIT 1;


mysql> EXPLAIN SELECT post_date_gmt FROM wp_posts WHERE post_status = 'publish' AND post_type IN ('post', 'page', 'attachment', 'pronamic_pay_form', 'tribe_events', 'tribe_venue', 'tribe_organizer', 'gallery', 'sports', 'epaper') ORDER BY post_date_gmt DESC LIMIT 1\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: wp_posts
         type: range
possible_keys: type_status_date,type_status_mime_type,type_status_comment_count
          key: type_status_comment_count
      key_len: 164
          ref: NULL
         rows: 687049
        Extra: Using where; Using filesort
1 row in set (0.01 sec)

mysql> ALTER TABLE wp_posts ADD INDEX type_status_date_gmt (post_type, post_status, post_date_gmt);
Query OK, 0 rows affected (16.86 sec)
Records: 0  Duplicates: 0  Warnings: 0

mysql> EXPLAIN SELECT post_date_gmt FROM wp_posts WHERE post_status = 'publish' AND post_type IN ('post', 'page', 'attachment', 'pronamic_pay_form', 'tribe_events', 'tribe_venue', 'tribe_organizer', 'gallery', 'sports', 'epaper') ORDER BY post_date_gmt DESC LIMIT 1\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: wp_posts
         type: range
possible_keys: type_status_date,type_status_mime_type,type_status_comment_count,type_status_date_gmt
          key: type_status_date_gmt
      key_len: 164
          ref: NULL
         rows: 687050
        Extra: Using where; Using index; Using filesort
1 row in set (0.00 sec)


mysql> SELECT post_date_gmt FROM wp_posts WHERE post_status = 'publish' AND post_type IN ('post', 'page', 'attachment', 'pronamic_pay_form', 'tribe_events', 'tribe_venue', 'tribe_organizer', 'gallery', 'sports', 'epaper') ORDER BY post_date_gmt DESC LIMIT 1\G
*************************** 1. row ***************************
post_date_gmt: 2016-04-15 13:02:59
1 row in set (0.98 sec)
```

#### Fix slow query for wp_postmeta.meta_value(40 bzw. UUID length)
Same for usermeta, termmeta, commentmeta?

#### Fix slow query for wp_usermeta.meta_key
Slow queries when filtering users by one or more meta fields.
```sql
ALTER TABLE wp_usermeta
ADD INDEX user_id_meta_key (user_id, meta_key);
```
