### PR TITLE
Fixed error in opt-out script when no Google Analytics ID is defined.

### DIFF
--- a/assets/scripts/google-analytics-opt-out.js
+++ b/assets/scripts/google-analytics-opt-out.js
@@ -1,5 +1,7 @@
 'use strict';
 
+window.gaIdList = window.gaIdList || [];
+
 // Disable tracking if the opt-out cookie exists.
 for (var i = 0; i < window.gaIdList.length; i++) {
   var disableStr = 'ga-disable-' + window.gaIdList[i];

--- a/core-standards.php
+++ b/core-standards.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Core Standards
-  Version: 1.22.1
+  Version: 1.22.2
   Text Domain: core-standards
   Description: Standard refinements.
   Author: netzstrategen

--- a/dist/scripts/google-analytics-opt-out.js
+++ b/dist/scripts/google-analytics-opt-out.js
@@ -6,6 +6,8 @@ function gaOptout() {
     window[o] = !0;
 }
 
+window.gaIdList = window.gaIdList || [];
+
 for (var i = 0; i < window.gaIdList.length; i++) {
     var disableStr = "ga-disable-" + window.gaIdList[i];
     document.cookie.indexOf(disableStr + "=true") > -1 && (window[disableStr] = !0);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core-standards",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "description": "core-standards",
   "main": "gulpfile.js",
   "devDependencies": {


### PR DESCRIPTION
Google opt-out script gives a JS error when window.gaIdList is not defined.
