### PR TITLE
Added constant allowing to disable cookie notice via wp-config.php.

### DIFF
--- a/core-standards.php
+++ b/core-standards.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Core Standards
-  Version: 1.22.3
+  Version: 1.22.4
   Text Domain: core-standards
   Description: Standard refinements.
   Author: netzstrategen

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core-standards",
-  "version": "1.22.3",
+  "version": "1.22.4",
   "description": "core-standards",
   "main": "gulpfile.js",
   "devDependencies": {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -90,7 +90,7 @@ class Plugin {
     // Output client-side cookie notice on all pages.
     // Use a slightly higher weight to prevent the bar being output
     // before other footer content.
-    if (!defined('CORE_STANDARDS_COOKIE_NOTICE') || CORE_STANDARDS_COOKIE_NOTICE === FALSE) {
+    if (!defined('CORE_STANDARDS_COOKIE_NOTICE') || CORE_STANDARDS_COOKIE_NOTICE !== FALSE) {
       add_action('wp_footer', __CLASS__ . '::wp_footer', 12);
     }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -88,7 +88,7 @@ class Plugin {
     add_action('rss2_item', __NAMESPACE__ . '\Feed::rss2_item');
 
     // Output client-side cookie notice on all pages.
-    // Use a slightly higher priority to prevent the bar being output
+    // Use a slightly higher weight to prevent the bar being output
     // before other footer content.
     if (!defined('CORE_STANDARDS_COOKIE_NOTICE') || CORE_STANDARDS_COOKIE_NOTICE === FALSE) {
       add_action('wp_footer', __CLASS__ . '::wp_footer', 12);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -90,7 +90,7 @@ class Plugin {
     // Output client-side cookie notice on all pages.
     // Use a slightly higher priority to prevent the bar being output
     // before other footer content.
-    if (!defined('CORE_STANDARDS_DISABLE_COOKIE_NOTICE') || CORE_STANDARDS_DISABLE_COOKIE_NOTICE === FALSE) {
+    if (!defined('CORE_STANDARDS_COOKIE_NOTICE') || CORE_STANDARDS_COOKIE_NOTICE === FALSE) {
       add_action('wp_footer', __CLASS__ . '::wp_footer', 12);
     }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -88,9 +88,11 @@ class Plugin {
     add_action('rss2_item', __NAMESPACE__ . '\Feed::rss2_item');
 
     // Output client-side cookie notice on all pages.
-    // Use a slightly higher weight to prevent the bar being output
+    // Use a slightly higher priority to prevent the bar being output
     // before other footer content.
-    add_action('wp_footer', __CLASS__ . '::wp_footer', 12);
+    if (!defined('CORE_STANDARDS_DISABLE_COOKIE_NOTICE') || CORE_STANDARDS_DISABLE_COOKIE_NOTICE === FALSE) {
+      add_action('wp_footer', __CLASS__ . '::wp_footer', 12);
+    }
 
     add_action(static::CRON_EVENT_ENSURE_INDEXES, __NAMESPACE__ . '\Schema::cron_ensure_indexes');
     if (!wp_next_scheduled(static::CRON_EVENT_ENSURE_INDEXES)) {


### PR DESCRIPTION
### Ticket
- [Deactivate Cookie notice in Core standards](https://app.asana.com/0/32260443473239/1122794580966854/f)

### Description
- Normally the cookie notice is enabled by default, but in edge cases a project might not need or want it.  The new constant allows to disable it via `wp-config.php` by setting:
```php
const CORE_STANDARDS_COOKIE_NOTICE = FALSE;
```
