### PR TITLE
Fixed SVG image uploads are not accepted by media library.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,9 +1,9 @@
 === Core Standards ===
-Contributors: netzstrategen, tha_sun, fabianmarz, juanlopez4691, lucapipolo
+Contributors: netzstrategen, tha_sun, fabianmarz, juanlopez4691, lucapipolo, colourgarden
 Tags: core, standards, defaults, enhancements, security
 Requires at least: 4.5
 Tested up to: 4.9.8
-Stable tag: 1.24.0
+Stable tag: 1.25.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/core-standards.php
+++ b/core-standards.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Core Standards
-  Version: 1.24.0
+  Version: 1.25.0
   Text Domain: core-standards
   Description: Standard refinements.
   Author: netzstrategen

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core-standards",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "Various features and adjustments for WordPress Core that do not need configuration.",
   "main": "gulpfile.js",
   "devDependencies": {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -68,6 +68,7 @@ class Plugin {
 
     // Allow SVG files in media library.
     add_filter('upload_mimes', __CLASS__ . '::upload_mime_types');
+    add_filter('wp_check_filetype_and_ext', __CLASS__ . '::wp_check_filetype_and_ext', 10, 4);
 
     // Prevent full-width images from getting wrapped into paragraphs.
     add_filter('the_content', __CLASS__ . '::the_content_before', 9);
@@ -142,6 +143,16 @@ class Plugin {
   public static function upload_mime_types(array $mimes) {
     $mimes['svg'] = 'image/svg+xml';
     return $mimes;
+  }
+
+  /**
+   * @implements wp_check_filetype_and_ext
+   */
+  public static function wp_check_filetype_and_ext(array $data, $file, $filename, $mimes) {
+    if (isset($data['ext']) && $data['ext'] === 'svg') {
+      $data['type'] = 'image/svg+xml';
+    }
+    return $data;
   }
 
   /**


### PR DESCRIPTION
### Ticket
- —

### Description
- Untested / unconfirmed.
    - The actual root cause in our case may not have been this missing code, but the specific SVG file instead, which was using `url()` to fill paths with gradients, but `url()` can be used as an attack vector.
    - We **temporarily** applied the constant `ALLOW_UNFILTERED_UPLOADS ` in `wp-config.php` instead (see https://css-tricks.com/snippets/wordpress/allow-svg-through-wordpress-media-uploader/#comment-1692805).
- This PR is based on https://css-tricks.com/snippets/wordpress/allow-svg-through-wordpress-media-uploader/#comment-1606220

### Alternative solutions
- https://wordpress.org/plugins/safe-svg/
- https://wordpress.org/plugins/svg-support/
