### PR TITLE
Added protection against DoS and brute-force attacks on wp-login.php and xmlrpc.php.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,34 @@
+=== Core Standards ===
+Contributors: netzstrategen, tha_sun, fabianmarz, juanlopez4691, lucapipolo
+Tags: core, standards, defaults, enhancements, security
+Requires at least: 4.5
+Tested up to: 4.9.8
+Stable tag: 1.23.2
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+Various features and adjustments for WordPress Core that do not need configuration.
+
+== Description ==
+
+Performs several adjustments to native WordPress functionality that should be in
+Core already but are not for different reasons (as the name implies).
+
+
+= Features =
+
+- Replaces the front controller `wp-login.php` with `login.php` and blocks
+  access to `wp-login.php` and `xmlrpc.php` to prevent Denial-of-Service (DoS)
+  and brute-force attacks.
+
+
+== Installation ==
+
+1. Extract the archive into the plugins directory as usual.
+
+2. Activate the plugin as usual.
+
+
+= Requirements =
+
+- PHP 7.1 or later.

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: netzstrategen, tha_sun, fabianmarz, juanlopez4691, lucapipolo
 Tags: core, standards, defaults, enhancements, security
 Requires at least: 4.5
 Tested up to: 4.9.8
-Stable tag: 1.23.2
+Stable tag: 1.24.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "netzstrategen/core-standards",
     "type": "wordpress-plugin",
+    "description": "Various features and adjustments for WordPress Core that do not need configuration.",
     "authors": [
         {
             "name": "netzstrategen",
@@ -9,7 +10,6 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0",
-        "composer/installers": "^1"
+        "php": ">=7.0.0"
     }
 }

--- a/conf/.htaccess.security
+++ b/conf/.htaccess.security
@@ -1,0 +1,9 @@
+# BEGIN core-standards:security
+<IfModule mod_rewrite.c>
+  # Rename /wp-login.php into /login.php and deny access to XML-RPC API.
+  RewriteEngine On
+  RewriteRule ^login\.php$ /wp-login.php [QSA,END]
+  RewriteRule ^wp-login\.php$ - [NS,F,END]
+  RewriteRule ^xmlrpc\.php$ - [F,END]
+</IfModule>
+# END core-standards:security

--- a/core-standards.php
+++ b/core-standards.php
@@ -38,7 +38,7 @@ register_uninstall_hook(__FILE__, __NAMESPACE__ . '\Schema::uninstall');
 add_action('wp_upgrade', __NAMESPACE__ . '\Schema::ensureUploadsHtaccess');
 
 add_action('widgets_init', __NAMESPACE__ . '\Widgets\UserLoginFormWidget::init');
-add_action('plugins_loaded', __NAMESPACE__ . '\Plugin::loadTextdomain');
+add_action('plugins_loaded', __NAMESPACE__ . '\Plugin::plugins_loaded');
 add_action('init', __NAMESPACE__ . '\Plugin::init', 20);
 add_action('admin_init', __NAMESPACE__ . '\Admin::init');
 // Adds settings fields to 'Reading' settings page, after 'Search Engine visibility'.

--- a/core-standards.php
+++ b/core-standards.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Core Standards
-  Version: 1.23.3
+  Version: 1.24.0
   Text Domain: core-standards
   Description: Standard refinements.
   Author: netzstrategen

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "core-standards",
-  "version": "1.23.3",
-  "description": "core-standards",
+  "version": "1.24.0",
+  "description": "Various features and adjustments for WordPress Core that do not need configuration.",
   "main": "gulpfile.js",
   "devDependencies": {
     "gulp": "3.9.1",

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -40,6 +40,18 @@ class Plugin {
   private static $baseUrl;
 
   /**
+   * @implements plugins_loaded
+   */
+  public static function plugins_loaded() {
+    // Change URLs pointing to /wp-login.php into /login.php.
+    add_filter('network_site_url', __NAMESPACE__ . '\Security::site_url', 100, 3);
+    add_filter('site_url', __NAMESPACE__ . '\Security::site_url', 100, 3);
+    add_filter('wp_redirect', __NAMESPACE__ . '\Security::wp_redirect', 1);
+
+    Plugin::loadTextdomain();
+  }
+
+  /**
    * @implements init
    */
   public static function init() {

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -23,6 +23,9 @@ class Schema {
 
     // Fast 404 responses for missing files in uploads folder.
     static::ensureFast404Response();
+
+    // Rename /wp-login.php into /login.php and deny access to XML-RPC API.
+    static::ensureFrontControllerAccess();
   }
 
   /**
@@ -77,6 +80,14 @@ class Schema {
     static::createOrPrependFile(ABSPATH . '.htaccess', $template, "\n");
     $template = file_get_contents(Plugin::getBasePath() . '/conf/remove/.htaccess.uploads.fast404');
     static::removeFromFile($uploads_dir . '/.htaccess', $template);
+  }
+
+  /**
+   * Ensures fast 404 responses for missing files in uploads folder.
+   */
+  public static function ensureFrontControllerAccess() {
+    $template = file_get_contents(Plugin::getBasePath() . '/conf/.htaccess.security');
+    Schema::createOrPrependFile(ABSPATH . '.htaccess', $template, "\n");
   }
 
   /**

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -83,11 +83,11 @@ class Schema {
   }
 
   /**
-   * Ensures fast 404 responses for missing files in uploads folder.
+   * Ensures no access to slow front controllers and creates route for login.php.
    */
   public static function ensureFrontControllerAccess() {
     $template = file_get_contents(Plugin::getBasePath() . '/conf/.htaccess.security');
-    Schema::createOrPrependFile(ABSPATH . '.htaccess', $template, "\n");
+    static::createOrPrependFile(ABSPATH . '.htaccess', $template, "\n");
   }
 
   /**

--- a/src/Security.php
+++ b/src/Security.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @file
+ * Contains \Netzstrategen\CoreStandards\Security.
+ */
+
+namespace Netzstrategen\CoreStandards;
+
+/**
+ * Protects the site against DoS and brute-force attacks.
+ */
+class Security {
+
+  /**
+   * @implements network_site_url
+   * @implements site_url
+   */
+  public static function site_url($url, $path, $scheme) {
+    if ($scheme === 'login' || $scheme === 'login_post') {
+      $url = strtr($url, ['/wp-login.php' => '/login.php']);
+    }
+    return $url;
+  }
+
+  /**
+   * @implements wp_redirect
+   */
+  public static function wp_redirect($url) {
+    $url = strtr($url, ['wp-login.php' => 'login.php']);
+    return $url;
+  }
+
+}


### PR DESCRIPTION
### Ticket
- https://netzstrategen.slack.com/archives/C03KDSK1E/p1563383725014000

### Description

- Replaces `/wp-login.php` with `/login.php` and blocks access to `/wp-login.php`.

- Updates all links and redirects in the system to point to the new front controller.

- Requires the core-standards plugin to be deactivated and activated to install the new rewrite rules in .htaccess.

- Replaces https://github.com/netzstrategen/mwk/pull/14

- Also protects against accesses to xmlrpc.php (and thus resolves 
[Performance: Ensure xmlrpc.php is blocked](https://app.asana.com/0/354170587449545/1131320151887257/f))