### PR TITLE
Added admin email setting as an enviromnent constant.

### DIFF
--- a/core-standards.php
+++ b/core-standards.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Core Standards
-  Version: 2.1.2
+  Version: 2.2.1
   Text Domain: core-standards
   Description: Standard refinements.
   Author: netzstrategen

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core-standards",
-  "version": "2.1.2",
+  "version": "2.2.1",
   "title": "WordPress Core Refinements",
   "description": "Various features and adjustments for WordPress Core that do not need configuration.",
   "main": "gulpfile.js",

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -99,6 +99,10 @@ class Plugin {
     add_action('wp_ajax_core-standards/log_cookie_consent', __CLASS__ . '::log_cookie_consent');
     add_action('wp_ajax_nopriv_core-standards/log_cookie_consent', __CLASS__ . '::log_cookie_consent');
 
+    // Sets admin email.
+    add_filter('option_admin_email', __CLASS__ . '::customAdminEmail', 99, 1);
+    add_filter('site_option_admin_email', __CLASS__ . '::customAdminEmail', 99, 1);
+
     if (is_admin()) {
       return;
     }
@@ -269,6 +273,19 @@ class Plugin {
     ];
     Logger::writelog($data);
     wp_die();
+  }
+
+  /**
+   * Sets site admin email.
+   *
+   * @param string $value
+   *   Admin email saved in wp_options table.
+   *
+   * @return string
+   *   Admin email.
+   */
+  public static function customAdminEmail($value) {
+    return defined('ADMIN_EMAIL') ? ADMIN_EMAIL : $value;
   }
 
   /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -278,6 +278,10 @@ class Plugin {
   /**
    * Sets site admin email.
    *
+   * Allows to override the site admin email address to block
+   * error notices/emails sent from development or staging
+   * environments.
+   *
    * @param string $value
    *   Admin email saved in wp_options table.
    *


### PR DESCRIPTION
### Ticket
- [Ensure Wordpress error emails are not sent to client](https://app.asana.com/0/587433704548192/1156992769948077/f)

### Description
- 
