### PR TITLE
Added constant for setting custom login path.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -21,6 +21,10 @@ Core already but are not for different reasons (as the name implies).
   access to `wp-login.php` and `xmlrpc.php` to prevent Denial-of-Service (DoS)
   and brute-force attacks.
 
+  For Apache, this requires `AllowOverride all` to be set for the directory of the
+  virtual host or the whole server (the latter is not recommended for production
+  servers).
+
 = Customization =
 
 By default, /wp-login.php is replaced with /login.php. You can use a custom path

--- a/README.txt
+++ b/README.txt
@@ -21,6 +21,21 @@ Core already but are not for different reasons (as the name implies).
   access to `wp-login.php` and `xmlrpc.php` to prevent Denial-of-Service (DoS)
   and brute-force attacks.
 
+= Customization =
+
+By default, /wp-login.php is replaced with /login.php. You can use a custom path
+by setting the constant CORE_STANDARDS_LOGIN_PATH in wp-config.php:
+```
+const CORE_STANDARDS_LOGIN_PATH = '/user/login';
+```
+and routing inbound requests on that path into the original /wp-login.php file
+by adding the following lines to the top of .htaccess:
+```
+# Route /user/login into /wp-login.php.
+RewriteEngine On
+RewriteRule ^/?user/login$ /wp-login.php [QSA,END]
+```
+
 
 == Installation ==
 

--- a/src/Security.php
+++ b/src/Security.php
@@ -9,6 +9,19 @@ namespace Netzstrategen\CoreStandards;
 
 /**
  * Protects the site against DoS and brute-force attacks.
+ *
+ * By default, /wp-login.php is replaced with /login.php. You can use a custom path
+ * by setting the constant CORE_STANDARDS_LOGIN_PATH in wp-config.php:
+ * ```
+ * const CORE_STANDARDS_LOGIN_PATH = '/user/login';
+ * ```
+ * and routing inbound requests on that path into the original /wp-login.php file
+ * by adding the following lines to the top of .htaccess:
+ * ```
+ * # Route /user/login into /wp-login.php.
+ * RewriteEngine On
+ * RewriteRule ^/?user/login$ /wp-login.php [QSA,END]
+ * ```
  */
 class Security {
 
@@ -18,7 +31,8 @@ class Security {
    */
   public static function site_url($url, $path, $scheme) {
     if ($scheme === 'login' || $scheme === 'login_post') {
-      $url = strtr($url, ['/wp-login.php' => '/login.php']);
+      $custom_path = defined('CORE_STANDARDS_LOGIN_PATH') ? CORE_STANDARDS_LOGIN_PATH : '/login.php';
+      $url = strtr($url, ['/wp-login.php' => $custom_path]);
     }
     return $url;
   }
@@ -27,7 +41,8 @@ class Security {
    * @implements wp_redirect
    */
   public static function wp_redirect($url) {
-    $url = strtr($url, ['wp-login.php' => 'login.php']);
+    $custom_path = defined('CORE_STANDARDS_LOGIN_PATH') ? CORE_STANDARDS_LOGIN_PATH : '/login.php';
+    $url = strtr($url, ['/wp-login.php' => $custom_path]);
     return $url;
   }
 


### PR DESCRIPTION
Poblem
* `/login.php` cannot be made available.

Goal
* Allow to set a custom path for the login page.

Details
* For a current project, WordPress lives behind a reverse proxy and only certain paths are reachable. `/login.php` cannot be made available.
