### PR TITLE
Fixed forgot password form posts to double-prefixed login path.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: netzstrategen, tha_sun, fabianmarz, juanlopez4691, lucapipolo, col
 Tags: core, standards, defaults, enhancements, security
 Requires at least: 4.5
 Tested up to: 4.9.8
-Stable tag: 2.3.0
+Stable tag: 2.3.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/core-standards.php
+++ b/core-standards.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Core Standards
-  Version: 2.3.0
+  Version: 2.3.1
   Text Domain: core-standards
   Description: Standard refinements.
   Author: netzstrategen

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core-standards",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "title": "WordPress Core Refinements",
   "description": "Various features and adjustments for WordPress Core that do not need configuration.",
   "main": "gulpfile.js",

--- a/src/Security.php
+++ b/src/Security.php
@@ -41,16 +41,16 @@ class Security {
    * @implements wp_redirect
    */
   public static function wp_redirect($url) {
-    $custom_path = defined('CORE_STANDARDS_LOGIN_PATH') ? CORE_STANDARDS_LOGIN_PATH : '/login.php';
+    $custom_path = defined('CORE_STANDARDS_LOGIN_PATH') ? CORE_STANDARDS_LOGIN_PATH : 'login.php';
 
     // wp-login.php calls wp_safe_redirect() with a relative path, which causes
     // wp_validate_redirect() to automatically prepend the current folder name
     // of the request URI to it. Prevent the path from being duplicated.
     if (strpos($url, dirname($custom_path)) === FALSE) {
-      $url = strtr($url, ['/wp-login.php' => $custom_path]);
+      $url = strtr($url, ['wp-login.php' => $custom_path]);
     }
     else {
-      $url = strtr($url, ['/wp-login.php' => '/' . basename($custom_path)]);
+      $url = strtr($url, ['wp-login.php' => basename($custom_path)]);
     }
     return $url;
   }

--- a/src/Security.php
+++ b/src/Security.php
@@ -42,12 +42,13 @@ class Security {
    */
   public static function wp_redirect($url) {
     $custom_path = defined('CORE_STANDARDS_LOGIN_PATH') ? CORE_STANDARDS_LOGIN_PATH : '/login.php';
+
+    // wp-login.php calls wp_safe_redirect() with a relative path, which causes
+    // wp_validate_redirect() to automatically prepend the current folder name
+    // of the request URI to it. Prevent the path from being duplicated.
     if (strpos($url, dirname($custom_path)) === FALSE) {
       $url = strtr($url, ['/wp-login.php' => $custom_path]);
     }
-    // wp-login.php calls wp_safe_redirect() with a relative path, which causes
-    // wp_validate_redirect() to automatically prepend the current folder name
-    // of the request URI to it.
     else {
       $url = strtr($url, ['/wp-login.php' => '/' . basename($custom_path)]);
     }

--- a/src/Security.php
+++ b/src/Security.php
@@ -42,7 +42,15 @@ class Security {
    */
   public static function wp_redirect($url) {
     $custom_path = defined('CORE_STANDARDS_LOGIN_PATH') ? CORE_STANDARDS_LOGIN_PATH : '/login.php';
-    $url = strtr($url, ['/wp-login.php' => $custom_path]);
+    if (strpos($url, dirname($custom_path)) === FALSE) {
+      $url = strtr($url, ['/wp-login.php' => $custom_path]);
+    }
+    // wp-login.php calls wp_safe_redirect() with a relative path, which causes
+    // wp_validate_redirect() to automatically prepend the current folder name
+    // of the request URI to it.
+    else {
+      $url = strtr($url, ['/wp-login.php' => '/' . basename($custom_path)]);
+    }
     return $url;
   }
 

--- a/src/Security.php
+++ b/src/Security.php
@@ -41,7 +41,7 @@ class Security {
    * @implements wp_redirect
    */
   public static function wp_redirect($url) {
-    $custom_path = defined('CORE_STANDARDS_LOGIN_PATH') ? CORE_STANDARDS_LOGIN_PATH : 'login.php';
+    $custom_path = defined('CORE_STANDARDS_LOGIN_PATH') ? CORE_STANDARDS_LOGIN_PATH : '/login.php';
 
     // wp-login.php calls wp_safe_redirect() with a relative path, which causes
     // wp_validate_redirect() to automatically prepend the current folder name


### PR DESCRIPTION
### Description
- The form submission redirects to an invalid path (duplicating the custom login path) if the custom login path contains a folder (such as `/my/login`).
- The minor version number is also bumped by this PR, because the PR that introduced the constant forgot to do so.
