### PR TITLE
Fix/empty admin email 1167274215992498 joan

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,8 +2,8 @@
 Contributors: netzstrategen, tha_sun, fabianmarz, juanlopez4691, lucapipolo, colourgarden
 Tags: core, standards, defaults, enhancements, security
 Requires at least: 4.5
-Tested up to: 4.9.8
-Stable tag: 2.3.1
+Tested up to: 5.3.2
+Stable tag: 2.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/core-standards.php
+++ b/core-standards.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Core Standards
-  Version: 2.3.1
+  Version: 2.3.2
   Text Domain: core-standards
   Description: Standard refinements.
   Author: netzstrategen

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core-standards",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "title": "WordPress Core Refinements",
   "description": "Various features and adjustments for WordPress Core that do not need configuration.",
   "main": "gulpfile.js",

--- a/src/Mail.php
+++ b/src/Mail.php
@@ -45,4 +45,21 @@ class Mail {
     return $message;
   }
 
+  /**
+   * Sets site admin email.
+   *
+   * Allows to override the site admin email address to block
+   * error notices/emails sent from development or staging
+   * environments.
+   *
+   * @param string $value
+   *   Admin email saved in wp_options table.
+   *
+   * @return string
+   *   Admin email.
+   */
+  public static function customAdminEmail($value) {
+    return defined('ADMIN_EMAIL') && ADMIN_EMAIL ? ADMIN_EMAIL : $value;
+  }
+
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -257,7 +257,7 @@ class Plugin {
    *   Admin email.
    */
   public static function customAdminEmail($value) {
-    return defined('ADMIN_EMAIL') ? ADMIN_EMAIL : $value;
+    return defined('ADMIN_EMAIL') && ADMIN_EMAIL ? ADMIN_EMAIL : $value;
   }
 
   /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -86,6 +86,10 @@ class Plugin {
     // Remove "[$blogname]" prefix in email subjects of user account mails.
     add_filter('wp_mail', __NAMESPACE__ . '\Mail::wp_mail');
 
+    // Sets admin email.
+    add_filter('option_admin_email', __NAMESPACE__ . '\Mail::customAdminEmail', 99, 1);
+    add_filter('site_option_admin_email', __NAMESPACE__ . '\Mail::customAdminEmail', 99, 1);
+
     add_shortcode('user-login-form', __NAMESPACE__ . '\UserLoginForm::getOutput');
 
     // Removes X-Pingback HTTP header, disables insertion of rel="pingback" tags,
@@ -95,10 +99,6 @@ class Plugin {
     add_filter('pre_option_default_ping_status', '__return_zero');
     add_filter('pre_option_default_pingback_flag', '__return_zero');
     add_filter('wp_insert_post_data' , __CLASS__ . '::wp_insert_post_data', 100);
-
-    // Sets admin email.
-    add_filter('option_admin_email', __CLASS__ . '::customAdminEmail', 99, 1);
-    add_filter('site_option_admin_email', __CLASS__ . '::customAdminEmail', 99, 1);
 
     if (is_admin()) {
       return;
@@ -241,23 +241,6 @@ class Plugin {
     unset($methods['pingback.ping']);
     unset($methods['pingback.extensions.getPingbacks']);
     return $methods;
-  }
-
-  /**
-   * Sets site admin email.
-   *
-   * Allows to override the site admin email address to block
-   * error notices/emails sent from development or staging
-   * environments.
-   *
-   * @param string $value
-   *   Admin email saved in wp_options table.
-   *
-   * @return string
-   *   Admin email.
-   */
-  public static function customAdminEmail($value) {
-    return defined('ADMIN_EMAIL') && ADMIN_EMAIL ? ADMIN_EMAIL : $value;
   }
 
   /**


### PR DESCRIPTION
### Ticket
- [Ensure Wordpress error emails are not sent to client](https://app.asana.com/0/587433704548192/1156992769948077/f)

### Description
- Ensured it is not possible to set an empty string as the admin email.
- Reorganized the code.
