### PR TITLE
Fixed WordPress admin UI is cluttered with messages notifying about new releases and more features.

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -72,9 +72,9 @@ class Admin {
    * @see http://premium.wpmudev.org/blog/hide-the-wordpress-update-notification/
    */
   public static function removeUselessCoreUpdateNagMessages() {
-      // @see wp-admin/includes/admin-filters.php
-      remove_action('admin_notices', 'update_nag', 3);
-      remove_action('admin_notices', 'maintenance_nag', 10);
+    // @see wp-admin/includes/admin-filters.php
+    remove_action('admin_notices', 'update_nag', 3);
+    remove_action('admin_notices', 'maintenance_nag', 10);
   }
 
   /**

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -72,11 +72,9 @@ class Admin {
    * @see http://premium.wpmudev.org/blog/hide-the-wordpress-update-notification/
    */
   public static function removeUselessCoreUpdateNagMessages() {
-    if (!current_user_can('update_core')) {
       // @see wp-admin/includes/admin-filters.php
       remove_action('admin_notices', 'update_nag', 3);
       remove_action('admin_notices', 'maintenance_nag', 10);
-    }
   }
 
   /**


### PR DESCRIPTION
### Ticket
- [Remove WordPress release update and WooCommerce.com bragging notices](https://app.asana.com/0/354170587449545/1197780930151545/f)

### Description
-
