### PR TITLE
Added caching for date filter options on administrative listing pages.

### DIFF
--- a/core-standards.php
+++ b/core-standards.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Core Standards
-  Version: 3.1.0
+  Version: 3.2.0
   Text Domain: core-standards
   Description: Standard refinements.
   Author: netzstrategen

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core-standards",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "title": "WordPress Core Refinements",
   "description": "Various features and adjustments for WordPress Core that do not need configuration.",
   "main": "gulpfile.js",

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -57,6 +57,10 @@ class Admin {
     add_filter('wp_prepare_attachment_for_js', __CLASS__ . '::wp_prepare_attachment_for_js');
     add_action('admin_head', __CLASS__ . '::admin_head');
 
+    // Cache available months for filtering posts and attachments.
+    add_filter('media_library_months_with_files', __NAMESPACE__ . '\AdminDateFilterCache::media_library_months_with_files');
+    add_filter('pre_months_dropdown_query', __NAMESPACE__ . '\AdminDateFilterCache::pre_months_dropdown_query', 10, 2);
+
     // Exclude subscribers from post author select options to prevent a performance
     // slowdown on sites with large amounts of non-administrative registered users.
     add_filter('wp_dropdown_users_args', __CLASS__ . '::wp_dropdown_users_args');

--- a/src/AdminDateFilterCache.php
+++ b/src/AdminDateFilterCache.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * @file
+ * Contains \Netzstrategen\CoreStandards\AdminDateFilterCache.
+ *
+ * @thanks https://github.com/Automattic/vip-go-mu-plugins-built/blob/master/performance/vip-tweaks.php
+ */
+
+namespace Netzstrategen\CoreStandards;
+
+class AdminDateFilterCache {
+
+  /**
+   * Caches an expensive query for available months/years in media library filters.
+   *
+   * @implements media_library_months_with_files
+   */
+  public static function media_library_months_with_files($months) {
+    // Abort if something else is customizing the value.
+    if (isset($months)) {
+      return $months;
+    }
+    return static::getAvailableMonths('attachment');
+  }
+
+  /**
+   * Caches an expensive query for available months/years in posts filters.
+   *
+   * @implements pre_months_dropdown_query
+   */
+  public static function pre_months_dropdown_query($months, $post_type) {
+    // Abort if something else is customizing the value.
+    if (isset($months)) {
+      return $months;
+    }
+    return static::getAvailableMonths($post_type);
+  }
+
+  /**
+   * Caches results of available months/years for a given post type.
+   *
+   * @param string $post_type
+   *   The post type for which to look up available months/years.
+   *
+   * @return object[]
+   *
+   * @see \WP_List_Table::months_dropdown()
+   * @see wp_enqueue_media()
+   */
+  public static function getAvailableMonths($post_type) {
+    global $wpdb;
+
+    $months = wp_cache_get($post_type, 'admin_date_filter');
+    if (is_array($months)) {
+      return $months;
+    }
+
+    $where_post_status = '';
+    if ($post_type !== 'attachment') {
+      $where_post_status = "AND post_status NOT IN ('auto-draft', 'trash')";
+    }
+
+    $months = $wpdb->get_results($wpdb->prepare("
+      SELECT DISTINCT YEAR( post_date ) AS year, MONTH( post_date ) AS month
+      FROM $wpdb->posts
+      WHERE post_type = %s $where_post_status
+      ORDER BY post_date DESC
+    ", $post_type));
+
+    wp_cache_set($post_type, $months, 'admin_date_filter', DAY_IN_SECONDS);
+    return $months;
+  }
+
+  /**
+   * Invalidates the cache for a post type when a new month is added.
+   *
+   * Only invalidates the cache when a new month is added. For deletions, the
+   * cache will just expire after a day.
+   *
+   * @param string $post_id
+   *   The post ID to add.
+   */
+  public static function invalidateCacheByPost($post_id) {
+    $post_type = get_post_type($post_id);
+    $months = wp_cache_get($post_type, 'admin_date_filter');
+    if (!is_array($months)) {
+      return false;
+    }
+
+    $year  = get_the_time('Y', $post_id);
+    $month = get_the_time('n', $post_id);
+
+    foreach ($months as $date) {
+      if ($year === $date->year && $month === $date->month) {
+        // The month/year option already exists, nothing to do.
+        return;
+      }
+    }
+    // The option does not exist yet, invalidate the cache.
+    wp_cache_delete($post_type, 'admin_date_filter');
+  }
+
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -68,6 +68,10 @@ class Plugin {
     // Enforce youtube-nocookie and add wrapper to oEmbed elements.
     add_filter('embed_oembed_html', __CLASS__ . '::embed_oembed_html', 10, 4);
 
+    // Invalidates the cache of available month filters in the admin.
+    add_action('add_attachment', __NAMESPACE__ . '\AdminDateFilterCache::invalidateCacheByPost');
+    add_action('save_post', __NAMESPACE__ . '\AdminDateFilterCache::invalidateCacheByPost');
+
     // Allow SVG files in media library.
     add_filter('upload_mimes', __CLASS__ . '::upload_mime_types');
     add_filter('wp_check_filetype_and_ext', __CLASS__ . '::wp_check_filetype_and_ext', 10, 4);


### PR DESCRIPTION
Task
- [Slow query Real Media Library Assets](https://app.asana.com/0/0/1202845994899013)

Code inspired by Automattic's WordPress.com VIP mu-plugin:
- https://github.com/Automattic/vip-go-mu-plugins-built/blob/master/performance/vip-tweaks.php

Related issues
- https://core.trac.wordpress.org/ticket/41675
- https://wordpress.stackexchange.com/questions/200376/disable-slow-media-queries

Notes
- This does not do anything on sites that do not have a persistent object cache set up.

TBD
- Should this use transients instead to also work on smaller sites that do not have a lot of infrastructure?
