### PR TITLE
Fixed language switch is not working for all commands.

### DIFF
--- a/core-standards.php
+++ b/core-standards.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Core Standards
-  Version: 3.2.0
+  Version: 3.2.1
   Text Domain: core-standards
   Description: Standard refinements.
   Author: netzstrategen

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core-standards",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "title": "WordPress Core Refinements",
   "description": "Various features and adjustments for WordPress Core that do not need configuration.",
   "main": "gulpfile.js",

--- a/src/Hooks/Language.php
+++ b/src/Hooks/Language.php
@@ -16,11 +16,12 @@ class Language {
    * results for all languages. Defaults to the language set in the plugin.
    *
    * Note: Currently supporting WPML only.
+   * Note: Using an env variable to avoid synopsis parser validation errors.
    *
    * ### EXAMPLES
    *
-   *    wp post list --lang=en
-   *    wp post list --lang=all
+   *    WPLANG=en wp post list
+   *    WPLANG=all wp post list
    *
    * @param array $args
    * @param array $assoc_args
@@ -30,9 +31,8 @@ class Language {
    */
   public static function limitLanguage(array $args, array $assoc_args, array $options): array {
     global $sitepress;
-    if ($sitepress && $lang = $assoc_args['lang'] ?? '') {
+    if ($sitepress && $lang = getenv('WPLANG') ?? '') {
       $sitepress->switch_lang($lang, TRUE);
-      unset($assoc_args['lang']);
     }
     return $args;
   }


### PR DESCRIPTION
### Description
- As you raised your concerns in #78 about the synopsis validation the language parameter is not working with the media command since it results in a `unknown --lang parameter` error.
- I was not able to find a proper solution without adding much code so I chose the way of using an environment variable instead
