### PR TITLE
Added missing indexes for wp-all-import processes.

### DIFF
--- a/core-standards.php
+++ b/core-standards.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Core Standards
-  Version: 3.2.1
+  Version: 3.3.0
   Text Domain: core-standards
   Description: Standard refinements.
   Author: netzstrategen

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core-standards",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "title": "WordPress Core Refinements",
   "description": "Various features and adjustments for WordPress Core that do not need configuration.",
   "main": "gulpfile.js",


### PR DESCRIPTION
### Ticket
- [Notion page](https://www.notion.so/netzstrategen/Escalation-Attachments-Import-Performance-d1a4b138476f4864bf8b7625fa6b69f3?pvs=4)

### Description
- Inspired by https://www.wpintense.com/2021/05/12/speeding-up-wp-all-import-imports-using-scalability-pro/
