### PR TITLE
Fixed missing index on real-media-library plugin lookup table.

### DIFF
--- a/core-standards.php
+++ b/core-standards.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Core Standards
-  Version: 3.3.0
+  Version: 3.3.1
   Text Domain: core-standards
   Description: Standard refinements.
   Author: netzstrategen

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core-standards",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "title": "WordPress Core Refinements",
   "description": "Various features and adjustments for WordPress Core that do not need configuration.",
   "main": "gulpfile.js",

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -256,8 +256,8 @@ class Schema {
     }
 
     // real-media-library lacks an index on its lookup table.
-    if ($wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $wpdb->prefix . 'wp_realmedialibrary_posts'))) {
-      self::ensureIndex('wp_realmedialibrary_posts', 'fid', 'fid');
+    if ($wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $wpdb->prefix . 'realmedialibrary_posts'))) {
+      self::ensureIndex('realmedialibrary_posts', 'fid', 'fid');
     }
   }
 

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -254,6 +254,11 @@ class Schema {
     if ($wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $wpdb->prefix . 'pmxi_hash'))) {
       self::ensureIndex('pmxi_hash', 'post_id', 'post_id');
     }
+
+    // real-media-library lacks an index on its lookup table.
+    if ($wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $wpdb->prefix . 'wp_realmedialibrary_posts'))) {
+      self::ensureIndex('wp_realmedialibrary_posts', 'fid', 'fid');
+    }
   }
 
   /**


### PR DESCRIPTION
### Description
- There is no real ticket for it but investigating the slow query log I found the following query multiple times which took around ~10s to complete.
- I used https://www.eversql.com/ so run an analysis which resulted in the following index optimisation suggestions
  ```
  ALTER TABLE `wp_realmedialibrary` ADD INDEX `wp_realmedialibrar_idx_parent_ord` (`parent`,`ord`);
  ALTER TABLE `wp_realmedialibrary_meta` ADD INDEX `wp_meta_idx_meta_key_realmedialibrar` (`meta_key`,`realmedialibrary_id`);
  ALTER TABLE `wp_realmedialibrary_posts` ADD INDEX `wp_posts_idx_fid` (`fid`);
  ```
- The other two suggested indexes didn't brought any significant difference in speed when checking locally


### Slow Query:
```mysql
# Time: 230414  9:41:36
# User@Host: xxx @ localhost []
# Thread_id: 1898460  Schema: xxx  QC_hit: No
# Query_time: 13.741745  Lock_time: 0.000190  Rows_sent: 555  Rows_examined: 8406835
# Rows_affected: 0  Bytes_sent: 53943
# Tmp_tables: 1  Tmp_disk_tables: 0  Tmp_table_sizes: 3770776
# Full_scan: Yes  Full_join: No  Tmp_table: Yes  Tmp_table_on_disk: No
# Filesort: Yes  Filesort_on_disk: No  Merge_passes: 0  Priority_queue: No
SET timestamp=1681458096;
SELECT tn.*,
        rmlicl.`cnt_hu` AS cnt,
        IFNULL(rmlicl.`cnt_hu`, (
            SELECT COUNT(*) FROM wp_realmedialibrary_posts AS rmlpostscnt
                INNER JOIN wp_icl_translations AS wpmlt
                ON wpmlt.element_id = rmlpostscnt.attachment
                AND wpmlt.element_type = 'post_attachment'
                AND wpmlt.language_code = 'hu'
                WHERE rmlpostscnt.fid = tn.id
        )) AS cnt_result,
        rml_meta_orderby.meta_value AS lastOrderBy,
        rml_meta_orderAutomatically.meta_value AS orderAutomatically,
        rml_meta_lastSubOrderBy.meta_value AS lastSubOrderBy,
        rml_meta_subOrderAutomatically.meta_value AS subOrderAutomatically
FROM wp_realmedialibrary AS tn
LEFT JOIN wp_realmedialibrary_meta rml_meta_orderby ON rml_meta_orderby.realmedialibrary_id = tn.ID AND rml_meta_orderby.meta_key = 'orderby'
LEFT JOIN wp_realmedialibrary_meta rml_meta_orderAutomatically ON rml_meta_orderAutomatically.realmedialibrary_id = tn.ID AND rml_meta_orderAutomatically.meta_key = 'orderAutomatically'
LEFT JOIN wp_realmedialibrary_meta rml_meta_lastSubOrderBy ON rml_meta_lastSubOrderBy.realmedialibrary_id = tn.ID AND rml_meta_lastSubOrderBy.meta_key = 'lastSubOrderBy'
LEFT JOIN wp_realmedialibrary_meta rml_meta_subOrderAutomatically ON rml_meta_subOrderAutomatically.realmedialibrary_id = tn.ID AND rml_meta_subOrderAutomatically.meta_key = 'subOrderAutomatically'
LEFT JOIN wp_realmedialibrary_icl_count AS rmlicl ON tn.id = rmlicl.fid
ORDER BY parent, ord;
```
