### PR TITLE
Fixed script versioning for multilingual sites

### DIFF
--- a/src/Asset.php
+++ b/src/Asset.php
@@ -37,12 +37,10 @@ class Asset {
           $new_src = str_replace($matches[1], 'ver=' . $git_version, $src);
         }
         else {
-          var_dump('else');
           $new_src = $src . '&ver=' . $git_version;
         }
       }
       else {
-        var_dump('second else');
         $new_src = $src . '?ver=' . $git_version;
       }
       $tag = str_replace($src, $new_src, $tag);

--- a/src/Asset.php
+++ b/src/Asset.php
@@ -26,11 +26,8 @@ class Asset {
    *   The tag to print with the version updated.
    */
   public static function loader_tag($tag, $handle, $src) {
-    $wp_scripts = wp_scripts();
-    $default_version = $wp_scripts->default_version;
-
     // Skip scripts loaded from remote URLs.
-    if (strpos($src, home_url()) !== 0) {
+    if (strpos($src, site_url()) !== 0) {
       return $tag;
     }
 
@@ -40,10 +37,12 @@ class Asset {
           $new_src = str_replace($matches[1], 'ver=' . $git_version, $src);
         }
         else {
+          var_dump('else');
           $new_src = $src . '&ver=' . $git_version;
         }
       }
       else {
+        var_dump('second else');
         $new_src = $src . '?ver=' . $git_version;
       }
       $tag = str_replace($src, $new_src, $tag);


### PR DESCRIPTION
### Ticket
- [Bug: Cookie Banner is displayed on every page](https://app.asana.com/0/inbox/1202457646009598/1204557859078385/1204600140167588)

### Description
As Hauraton is a multilingual site, the use of `home_url` for the conditional comparison was causing mismatched as the source URL was `https://www.hauraton.com/assets/...` and the `home_url` was `https://www.hauraton.com/de/`. This was causing that the commit hash was never used.
Also I removed the use of `$wp_scripts` as it was not used.
