### PR TITLE
Added postmeta index for meta_key and meta_value to improve lookup query performance.

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -224,6 +224,10 @@ class Schema {
     // values, but there is no index on the values by default as it is a longtext
     // column.
     self::ensureIndex('postmeta', 'meta_value', 'meta_value(60)');
+    // Lookup queries filtering by meta_key and meta_value indicate that the
+    // meta_value index is not sufficiently reducing the result set to filter and
+    // sort the rest in memory.
+    self::ensureIndex('postmeta', 'meta_key_value', 'meta_key(80), meta_value(111)');
 
     // Data migration and import scripts and plugins are trying to locate
     // previously migrated content by its UUID, but the GUID column does not have


### PR DESCRIPTION
### Task
- [Product: Add index meta_key_value](https://app.asana.com/0/0/1204852800414557)

### Description
- Lookup queries on specific meta fields in a very large database can be slow.
- core-standards already adds the `meta_value` index, but it only covers some strange cases in core and contributed plugins that are filtering by `meta_value` column only (e.g. to retrieve all distinct values) or the value is so unique among all meta fields that it doesn't require further filtering by key; e.g., a URL.
- The much more common case are lookup queries checking a particular `meta_key` for a particular `meta_value`.
- MySQL/MariaDB still uses the `meta_value` index for those, but `EXPLAIN` states that it still has to go through thousands of rows to reduce them to the given meta key, which is slow.

### Examples

TODO: Need to find the actual queries that triggered this – for now here's a trivial:

```console
$ wp db query "EXPLAIN SELECT post_id FROM wp_postmeta WHERE meta_key = '_pub_id' AND meta_value = '12345'"
+------+-------------+-------------+------+---------------------+------------+---------+-------+------+-------------+
| id   | select_type | table       | type | possible_keys       | key        | key_len | ref   | rows | Extra       |
+------+-------------+-------------+------+---------------------+------------+---------+-------+------+-------------+
|    1 | SIMPLE      | wp_postmeta | ref  | meta_key,meta_value | meta_value | 243     | const | 1    | Using where |
+------+-------------+-------------+------+---------------------+------------+---------+-------+------+-------------+
```
(_"using where"_ should ideally say _"using index"_; the real cases had 4k rows, the new index reduced them to <100)

We can see that MariaDB 10.4+ already has a built-in optimization, which doesn't need the new index, because it's using a second index to filter the first:
```console
$ wp db query "EXPLAIN SELECT post_id FROM wp_postmeta WHERE meta_key = '_pub_id' AND meta_value = '12345'"
+------+-------------+-------------+------------+------------------------------------+---------------------+---------+-------+--------+---------------------------------+
| id   | select_type | table       | type       | possible_keys                      | key                 | key_len | ref   | rows   | Extra                           |
+------+-------------+-------------+------------+------------------------------------+---------------------+---------+-------+--------+---------------------------------+
|    1 | SIMPLE      | wp_postmeta | ref|filter | meta_key,meta_value,meta_key_value | meta_key|meta_value | 767|243 | const | 1 (0%) | Using where; Using rowid filter |
+------+-------------+-------------+------------+------------------------------------+---------------------+---------+-------+--------+---------------------------------+
```
