### PR TITLE
Fixed PHP 8.1 warning about passing null to a parameter.

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -210,7 +210,7 @@ class Admin {
       parse_str($_COOKIE['wp-settings-' . $user->ID], $cookie_settings);
       $cookie_settings = http_build_query(array_merge($cookie_settings, $overrides));
       $secure = ('https' === parse_url(admin_url(), PHP_URL_SCHEME));
-      setcookie('wp-settings-' . $user->ID, $cookie_settings, time() + YEAR_IN_SECONDS, SITECOOKIEPATH, null, $secure);
+      setcookie('wp-settings-' . $user->ID, $cookie_settings, time() + YEAR_IN_SECONDS, SITECOOKIEPATH, '', $secure);
       $_COOKIE['wp-settings-' . $user->ID] = $cookie_settings;
     }
     return $settings;


### PR DESCRIPTION
Displayed error
```
Deprecated: setcookie(): Passing null to parameter #5 ($domain) of type string is deprecated in /var/www/vhosts/stage.ltur.netz.rocks/htdocs/wp-content/plugins/core-standards/src/Admin.php on line 213
```